### PR TITLE
Patch request-toolbelt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "python-dateutil",
     "requests",
-		"requests_toolbelt",
+		"requests_toolbelt>=1.0.0",
     "ruamel.yaml>=0.17.26",
     "typer>=0.9.0",
     "rich"

--- a/src/fairly/dataset/remote.py
+++ b/src/fairly/dataset/remote.py
@@ -7,7 +7,7 @@ from . import Dataset
 from ..metadata import Metadata
 from ..file.local import LocalFile
 from ..file.remote import RemoteFile
-# FIXME: Importing Client results in circular dependency
+# FIXME: Importing Client or LocalDataset results in circular dependency
 # from ..client import Client
 
 import os
@@ -88,7 +88,12 @@ class RemoteDataset(Dataset):
                 path = path.replace(sep, "_")
 
         os.makedirs(path, exist_ok=True)
-        if os.listdir(path):
+
+        # check if directory is empty,
+        # while ignoring hidden files or directories
+        entries = os.listdir(path)
+        visible_entries = [entry for entry in entries if not entry.startswith(".")]
+        if len(visible_entries) > 0:
             raise ValueError("Directory is not empty.")
 
         templates = fairly.metadata_templates()


### PR DESCRIPTION
Versions older than 1.0.0 of **requests-toolbelt** create a conflict with the newest version of requests and urllib3. This is caused by the Google Engine App. In version 1.0.0 support for such a module was dropped to make the toolbelt compatible with the newest versions of requests and urllib3.  See: https://pypi.org/project/requests-toolbelt/

This PR modifies the `project.toml` to require at least version 1.0.0 of requests-toolbelt because supporting the Google Engine App is not relevant. Some tests show that this version of the toolbelt is compatible with older versions of requests and urllib3 (in the context of fairly)

### Error message:

```python
 Traceback (most recent call last):
      File "/home/manuel/miniconda3/envs/jupyterfair3/lib/python3.10/site-packages/tornado/web.py", line 1784, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/home/manuel/miniconda3/envs/jupyterfair3/lib/python3.10/site-packages/tornado/web.py", line 3290, in wrapper
        return method(self, *args, **kwargs)
      File "/home/manuel/Documents/devel/jupyter-fairly/jupyter_fairly/jupyter_fairly/handlers.py", line 184, in post
        dataset = fairly.dataset(data["source"])
      File "/home/manuel/Documents/devel/fairly/src/fairly/__init__.py", line 318, in dataset
        for repository_id, repository in get_repositories().items():
      File "/home/manuel/Documents/devel/fairly/src/fairly/__init__.py", line 177, in get_repositories
        clients = get_clients()
      File "/home/manuel/Documents/devel/fairly/src/fairly/__init__.py", line 113, in get_clients
        client = importlib.import_module(f"fairly.client.{id}")
      File "/home/manuel/miniconda3/envs/jupyterfair3/lib/python3.10/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
      File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
      File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 883, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "/home/manuel/Documents/devel/fairly/src/fairly/client/zenodo.py", line 15, in <module>
        from requests_toolbelt.multipart.encoder import MultipartEncoderMonitor
      File "/home/manuel/.local/lib/python3.10/site-packages/requests_toolbelt/__init__.py", line 12, in <module>
        from .adapters import SSLAdapter, SourceAddressAdapter
      File "/home/manuel/.local/lib/python3.10/site-packages/requests_toolbelt/adapters/__init__.py", line 12, in <module>
        from .ssl import SSLAdapter
      File "/home/manuel/.local/lib/python3.10/site-packages/requests_toolbelt/adapters/ssl.py", line 16, in <module>
        from .._compat import poolmanager
      File "/home/manuel/.local/lib/python3.10/site-packages/requests_toolbelt/_compat.py", line 50, in <module>
        from urllib3.contrib import appengine as gaecontrib
    ImportError: cannot import name 'appengine' from 'urllib3.contrib' (/home/manuel/miniconda3/envs/jupyterfair3/lib/python3.10/site-packages/urllib3/contrib/__init__.py)
```
