### PR TITLE
remove osf page from index in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,6 @@ Fairly Toolset Documentation
    :maxdepth: 2
    :caption: Fairly Package
 
-   osf2023
    installation
 
 .. toctree::


### PR DESCRIPTION
The OSF page was meant to be temporal, and now it is not relevant.