### PR TITLE
Use Hatch as build tooling for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include src/fairly/data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fairly"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   { name="Serkan Girgin", email="s.girgin@utwente.nl" },
   { name="Manuel Garcia Alvarez", email="m.g.garciaalvarez@tudelft.nl" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "fairly"
 version = "0.4.1"


### PR DESCRIPTION
- Substitute setup-tools for hatching build system. This shall make packaging simpler.
- Remove MANIFEST.in. This file contained a path to include the files in the `src/data` directory. However this in not necessary because the data directory is part of src, and hatch will pack inside src.  